### PR TITLE
Support scanning arbitrary modules other than ./...

### DIFF
--- a/pkg/modpath/modpath.go
+++ b/pkg/modpath/modpath.go
@@ -1,0 +1,26 @@
+package modpath
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+func DirFromFileAndMod(filePath, mod, modVer string) (string, error) {
+	modPath := StripMajorVersion(mod)
+	modOSPath := filepath.FromSlash(modPath)
+	idx := strings.Index(filePath, modOSPath)
+	if idx < 0 {
+		return "", fmt.Errorf("module path %q not found in file path %q", modOSPath, filePath)
+	}
+	root := filePath[:idx+len(modOSPath)]
+	if strings.Contains(filepath.ToSlash(root), "/pkg/mod/") && modVer != "" {
+		root += "@" + modVer
+	}
+	return root, nil
+}
+
+func StripMajorVersion(pkg string) string {
+	return regexp.MustCompile(`(/v[0-9]+)$`).ReplaceAllString(pkg, "")
+}

--- a/pkg/modpath/modpath_test.go
+++ b/pkg/modpath/modpath_test.go
@@ -1,0 +1,67 @@
+package modpath
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestDirFromFileAndPkg(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		Mod     string
+		modVer  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "Without version suffix",
+			file:   "/Users/me/gopath/src/github.com/containerd/containerd/pkg/archive/tar.go",
+			Mod:    "github.com/containerd/containerd",
+			modVer: "v1.0.0",
+			want:   "/Users/me/gopath/src/github.com/containerd/containerd",
+		},
+		{
+			name:   "With /v2 version suffix",
+			file:   "/Users/me/gopath/src/github.com/containerd/containerd/pkg/archive/tar.go",
+			Mod:    "github.com/containerd/containerd/v2",
+			modVer: "v2.0.0",
+			want:   "/Users/me/gopath/src/github.com/containerd/containerd",
+		},
+		{
+			name:   "Without /v2 version suffix, in GOPATH/pkg/mod",
+			file:   "/Users/me/gopath/pkg/mod/github.com/containerd/containerd@v1.0.0/pkg/archive/tar.go",
+			Mod:    "github.com/containerd/containerd",
+			modVer: "v1.0.0",
+			want:   "/Users/me/gopath/pkg/mod/github.com/containerd/containerd@v1.0.0",
+		},
+		{
+			name:   "With /v2 version suffix, in GOPATH/pkg/mod",
+			file:   "/Users/me/gopath/pkg/mod/github.com/containerd/containerd@v2.0.0/pkg/archive/tar.go",
+			Mod:    "github.com/containerd/containerd/v2",
+			modVer: "v2.0.0",
+			want:   "/Users/me/gopath/pkg/mod/github.com/containerd/containerd@v2.0.0",
+		},
+		{
+			name:    "Module path not found",
+			file:    "/some/other/path/main.go",
+			Mod:     "github.com/containerd/containerd",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root, err := DirFromFileAndMod(tc.file, tc.Mod, tc.modVer)
+			if tc.wantErr {
+				assert.ErrorContains(t, err, "module path")
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, tc.want, root)
+			assert.Assert(t, strings.HasPrefix(tc.file, tc.want))
+		})
+	}
+}


### PR DESCRIPTION
Fix #4, with a a dirty workaround for golang/go#73878