### PR TITLE
Support `//gosocialcheck:trusted` directive to silence warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,28 @@ import 'github.com/lmittmann/tint': module 'github.com/lmittmann/tint@v1.0.7' do
 ```
 
 ## Hints
+### Allowlist
+
+Use `//gosocialcheck:trusted` [directives](https://github.com/AkihiroSuda/gomoddirectivecomments) in `go.mod` to silence alerts for trustworthy modules.
+
+e.g.,
+```go-module
+//gosocialcheck:trusted
+require (
+	golang.org/x/sync v0.19.0
+)
+```
+
+or
+
+```go-module
+require (
+	golang.org/x/sync v0.19.0 //gosocialcheck:trusted
+)
+```
+
+Note: The directive ignores the module version.
+
 ### GitHub API rate limit
 gosocialcheck uses the GitHub API for the following operations:
 - Fetch git tags, via `api.github.com`.

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,19 @@ module github.com/AkihiroSuda/gosocialcheck
 
 go 1.24.0
 
+// My own packages and golang.org/x packages are trusted
+//gosocialcheck:trusted
+require (
+	github.com/AkihiroSuda/gomoddirectivecomments v0.1.0
+	golang.org/x/mod v0.33.0
+	golang.org/x/sync v0.19.0 // gomodjail:unconfined
+	golang.org/x/tools v0.41.0 // gomodjail:unconfined
+)
+
 require (
 	github.com/lmittmann/tint v1.1.3 // gomodjail:unconfined
 	github.com/spf13/cobra v1.10.2 // gomodjail:unconfined
 	github.com/spf13/pflag v1.0.10
-	golang.org/x/mod v0.32.0
-	golang.org/x/sync v0.19.0 // gomodjail:unconfined
-	golang.org/x/tools v0.41.0 // gomodjail:unconfined
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/AkihiroSuda/gomoddirectivecomments v0.1.0 h1:5sKxYIkq9GGs0DTnuPNVm2Z/LmhKdTN+8QblThzTKqg=
+github.com/AkihiroSuda/gomoddirectivecomments v0.1.0/go.mod h1:flXOhVLWfsi4FuFhFoc9F3m7wAH2RT4aM3fVyQROKt4=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -12,8 +14,8 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/mod v0.32.0 h1:9F4d3PHLljb6x//jOyokMv3eX+YDeepZSEo3mFJy93c=
-golang.org/x/mod v0.32.0/go.mod h1:SgipZ/3h2Ci89DlEtEXWUk/HteuRin+HHhN+WbNhguU=
+golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
+golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/tools v0.41.0 h1:a9b8iMweWG+S0OBnlU36rzLp20z1Rp10w+IY2czHTQc=


### PR DESCRIPTION
Fix #8 