### PR TITLE
Embed the database in the binary to make `gosocialcheck update` optional

### DIFF
--- a/.github/workflows/update-db.yml
+++ b/.github/workflows/update-db.yml
@@ -1,0 +1,48 @@
+name: Update the embedded database
+# Periodically updates pkg/embeddeddb/db, so that `gosocialcheck run` can work
+# without running `gosocialcheck update` first.
+# https://github.com/AkihiroSuda/gosocialcheck/issues/45
+#
+# This workflow never commits to the master branch directly:
+# it pushes the "update-db" branch and opens a pull request.
+on:
+  schedule:
+    - cron: '30 5 * * 1'  # Mondays
+  workflow_dispatch:
+permissions:
+  contents: write  # only used to push the "update-db" branch
+  pull-requests: write  # used to open the pull request
+jobs:
+  update-db:
+    if: github.repository == 'AkihiroSuda/gosocialcheck'
+    env:
+      GOTOOLCHAIN: local
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: true  # needed to push the "update-db" branch
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version: oldstable
+      - run: go run ./cmd/gosocialcheck update --dir ./pkg/embeddeddb/db
+      - name: Open a pull request
+        run: |
+          set -eux
+          if [ -z "$(git status --porcelain pkg/embeddeddb/db)" ]; then
+            echo "No changes"
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout -B update-db
+          git add pkg/embeddeddb/db
+          git commit -s -m 'Update the embedded database'
+          git push -f origin update-db
+          if [ -z "$(gh pr list --head update-db --state open --json number --jq '.[].number')" ]; then
+            gh pr create --base master --head update-db \
+              --title 'Update the embedded database' \
+              --body 'Automated update of pkg/embeddeddb/db by the "Update the embedded database" workflow.'
+          fi

--- a/README.md
+++ b/README.md
@@ -7,16 +7,13 @@ List of trusted projects:
 
 ## Install
 ```bash
-go install github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck@latest
+# Specify @master to use the latest database.
+# Specify @vX.Y.Z to use a specific version.
+go install github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck@master
 ```
 
 ## Usage
 ```
-# Set the token if facing the GitHub API rate limit (see below)
-export GITHUB_TOKEN=...
-
-gosocialcheck update
-
 gosocialcheck run ./...
 ```
 
@@ -56,8 +53,20 @@ require (
 
 Note: The directive ignores the module version.
 
-### GitHub API rate limit
-gosocialcheck uses the GitHub API for the following operations:
+### Updating the database
+
+The database is ([periodically committed](.github/workflows/update-db.yml) to `pkg/embeddeddb/db`.
+
+To fetch the latest database, run:
+```
+# Set the token if facing the GitHub API rate limit (see below)
+export GITHUB_TOKEN=...
+
+gosocialcheck update
+```
+
+#### GitHub API rate limit
+`gosocialcheck update` uses the GitHub API for the following operations:
 - Fetch git tags, via `api.github.com`.
 - Fetch `go.mod` and `go.sum`, via `https://raw.githubusercontent.com`.
 

--- a/cmd/gosocialcheck/commands/lookup/lookup.go
+++ b/cmd/gosocialcheck/commands/lookup/lookup.go
@@ -2,10 +2,14 @@ package lookup
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
 
 	"github.com/spf13/cobra"
 
 	"github.com/AkihiroSuda/gosocialcheck/pkg/cache"
+	"github.com/AkihiroSuda/gosocialcheck/pkg/embeddeddb"
 )
 
 func New() *cobra.Command {
@@ -22,12 +26,25 @@ func New() *cobra.Command {
 func action(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	sum := args[0]
-	c, err := cache.New()
+	embFS, err := embeddeddb.FS()
+	if err != nil {
+		return err
+	}
+	c, err := cache.New(cache.WithExtraFS(embFS))
 	if err != nil {
 		return err
 	}
 	if _, err = c.LastUpdated(); err != nil {
-		return err
+		if !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+		embEmpty, embErr := embeddeddb.IsEmpty()
+		if embErr != nil {
+			return embErr
+		}
+		if embEmpty {
+			return fmt.Errorf("the database is not populated yet (hint: run `gosocialcheck update`): %w", err)
+		}
 	}
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetEscapeHTML(false)

--- a/cmd/gosocialcheck/commands/run/run.go
+++ b/cmd/gosocialcheck/commands/run/run.go
@@ -1,6 +1,10 @@
 package run
 
 import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -9,6 +13,7 @@ import (
 	"github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck/flagutil"
 	"github.com/AkihiroSuda/gosocialcheck/pkg/analyzer"
 	"github.com/AkihiroSuda/gosocialcheck/pkg/cache"
+	"github.com/AkihiroSuda/gosocialcheck/pkg/embeddeddb"
 )
 
 func New() *cobra.Command {
@@ -32,12 +37,27 @@ func action(cmd *cobra.Command, args []string) error {
 	os.Args = append([]string{"gosocialcheck-run"}, args...)
 
 	ctx := cmd.Context()
-	c, err := cache.New()
+	embFS, err := embeddeddb.FS()
+	if err != nil {
+		return err
+	}
+	c, err := cache.New(cache.WithExtraFS(embFS))
 	if err != nil {
 		return err
 	}
 	if _, err = c.LastUpdated(); err != nil {
-		return err
+		if !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+		embEmpty, embErr := embeddeddb.IsEmpty()
+		if embErr != nil {
+			return embErr
+		}
+		if embEmpty {
+			return fmt.Errorf("the database is not populated yet (hint: run `gosocialcheck update`): %w", err)
+		}
+		slog.WarnContext(ctx, "The local database is not populated yet; falling back to the database that was embedded in the binary at build time. "+
+			"Run `gosocialcheck update` to fetch the latest database.")
 	}
 	flags := cmd.Flags()
 	goflags := flagutil.PFlagSetToGoFlagSet(flags, []string{"debug"})

--- a/cmd/gosocialcheck/commands/update/update.go
+++ b/cmd/gosocialcheck/commands/update/update.go
@@ -2,7 +2,10 @@ package update
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -17,6 +20,13 @@ func New() *cobra.Command {
 		RunE:                  action,
 		DisableFlagsInUseLine: true,
 	}
+	flags := cmd.Flags()
+	dirHelp := "database directory; mainly for maintaining pkg/embeddeddb/db"
+	if d, err := os.UserCacheDir(); err == nil {
+		dirHelp = fmt.Sprintf("database directory (default: %s); mainly for maintaining pkg/embeddeddb/db",
+			filepath.Join(d, "gosocialcheck"))
+	}
+	flags.String("dir", "", dirHelp)
 	return cmd
 }
 
@@ -25,7 +35,16 @@ func action(cmd *cobra.Command, args []string) error {
 	onProgress := func(ctx context.Context, ev cache.ProgressEvent) {
 		slog.InfoContext(ctx, "progress: "+ev.Message)
 	}
-	c, err := cache.New(cache.WithProgressEventHandler(onProgress))
+	opts := []cache.Opt{cache.WithProgressEventHandler(onProgress)}
+	flags := cmd.Flags()
+	dir, err := flags.GetString("dir")
+	if err != nil {
+		return err
+	}
+	if dir != "" {
+		opts = append(opts, cache.WithDir(dir))
+	}
+	c, err := cache.New(opts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/gosocialcheck/main.go
+++ b/cmd/gosocialcheck/main.go
@@ -31,12 +31,11 @@ func main() {
 }
 
 const example = `
-  # Set the token if facing the GitHub API rate limit (see README.md)
-  export GITHUB_TOKEN=...
-
-  gosocialcheck update
-
   gosocialcheck run ./...
+
+  # Optional: fetch the latest database (see README.md for $GITHUB_TOKEN)
+  export GITHUB_TOKEN=...
+  gosocialcheck update
 `
 
 func newRootCommand() *cobra.Command {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -55,6 +55,7 @@ func DefaultProgressEventHandler(ctx context.Context, ev ProgressEvent) {
 
 type opts struct {
 	dir        string
+	extraFS    fs.FS
 	onProgress ProgressEventHandler
 	httpClient *http.Client
 }
@@ -64,6 +65,16 @@ type Opt func(*opts) error
 func WithDir(dir string) Opt {
 	return func(opts *opts) error {
 		opts.dir = dir
+		return nil
+	}
+}
+
+// WithExtraFS adds an extra read-only database with the same layout as the
+// cache directory, such as [github.com/AkihiroSuda/gosocialcheck/pkg/embeddeddb.FS].
+// Entries found in the extra database are merged into the [Cache.Lookup] results.
+func WithExtraFS(fsys fs.FS) Opt {
+	return func(opts *opts) error {
+		opts.extraFS = fsys
 		return nil
 	}
 }
@@ -103,11 +114,15 @@ func New(o ...Opt) (*Cache, error) {
 	if c.opts.httpClient == nil {
 		c.opts.httpClient = http.DefaultClient
 	}
+	if c.opts.extraFS != nil {
+		c.extra = &fsDB{fsys: c.opts.extraFS}
+	}
 	return &c, nil
 }
 
 type Cache struct {
 	opts
+	extra   *fsDB
 	updated []string
 }
 
@@ -274,6 +289,28 @@ func (c *Cache) Lookup(ctx context.Context, sum string) ([]Meta, error) {
 	if !strings.HasPrefix(sum, "h1:") || !strings.HasSuffix(sum, "=") {
 		return nil, fmt.Errorf("expected h1 sum, got %q", sum)
 	}
+	res, err := c.lookupDir(ctx, sum)
+	if err != nil {
+		return res, err
+	}
+	if c.extra != nil {
+		extra, err := c.extra.lookup(sum)
+		if err != nil {
+			return res, err
+		}
+		res = mergeMetas(res, extra)
+	}
+	return res, nil
+}
+
+func (c *Cache) lookupDir(ctx context.Context, sum string) ([]Meta, error) {
+	if _, err := os.Stat(c.dir); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// The cache directory does not exist on the first run.
+			return nil, nil
+		}
+		return nil, err
+	}
 	goSumFiles, err := c.lookupGoSumFiles(ctx, sum)
 	if err != nil {
 		return nil, err
@@ -293,6 +330,22 @@ func (c *Cache) Lookup(ctx context.Context, sum string) ([]Meta, error) {
 		res = append(res, m)
 	}
 	return res, nil
+}
+
+func mergeMetas(metas ...[]Meta) []Meta {
+	var res []Meta
+	seen := make(map[string]struct{})
+	for _, mm := range metas {
+		for _, m := range mm {
+			key := m.Repo.Owner + "/" + m.Repo.Repo + "@" + m.Tag.Commit.SHA
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			res = append(res, m)
+		}
+	}
+	return res
 }
 
 func (c *Cache) lookupGoSumFiles(ctx context.Context, sum string) ([]string, error) {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,0 +1,81 @@
+package cache
+
+import (
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"gotest.tools/v3/assert"
+)
+
+func newTestFS() fstest.MapFS {
+	const (
+		fooMeta  = `{"repo":{"owner":"foo","repo":"foo"},"tag":{"name":"v1.0.0","commit":{"sha":"f00"}},"category":"test"}`
+		barMeta  = `{"repo":{"owner":"bar","repo":"bar"},"tag":{"name":"v2.0.0","commit":{"sha":"ba2"}},"category":"test"}`
+		fooGoSum = `example.com/aaa v1.0.0 h1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=
+example.com/aaa v1.0.0/go.mod h1:gomodgomodgomodgomodgomodgomodgomodgomodgom=
+example.com/bbb v1.2.3 h1:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb=
+example.com/bbb v1.2.3/go.mod h1:dommdommdommdommdommdommdommdommdommdommdom=
+`
+		barGoSum = `example.com/bbb v1.2.3 h1:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb=
+example.com/bbb v1.2.3/go.mod h1:dommdommdommdommdommdommdommdommdommdommdom=
+`
+	)
+	return fstest.MapFS{
+		"github.com/foo/foo/f00/go.sum":                  &fstest.MapFile{Data: []byte(fooGoSum)},
+		"github.com/foo/foo/f00/" + MetaFilename:         &fstest.MapFile{Data: []byte(fooMeta)},
+		"github.com/bar/bar/ba2/go.sum":                  &fstest.MapFile{Data: []byte(barGoSum)},
+		"github.com/bar/bar/ba2/" + MetaFilename:         &fstest.MapFile{Data: []byte(barMeta)},
+		"github.com/qux/qux/c0ffee/" + MetaFilename + "": &fstest.MapFile{Data: []byte(`{}`)}, // no go.sum (not Go code)
+	}
+}
+
+func TestFSDB(t *testing.T) {
+	db := &fsDB{fsys: newTestFS()}
+
+	t.Run("single hit", func(t *testing.T) {
+		res, err := db.lookup("h1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=")
+		assert.NilError(t, err)
+		assert.Equal(t, 1, len(res))
+		assert.Equal(t, "foo", res[0].Repo.Owner)
+	})
+
+	t.Run("multiple hits", func(t *testing.T) {
+		res, err := db.lookup("h1:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb=")
+		assert.NilError(t, err)
+		assert.Equal(t, 2, len(res))
+	})
+
+	t.Run("miss", func(t *testing.T) {
+		res, err := db.lookup("h1:ccccccccccccccccccccccccccccccccccccccccccc=")
+		assert.NilError(t, err)
+		assert.Equal(t, 0, len(res))
+	})
+
+	t.Run("go.mod sums are not indexed", func(t *testing.T) {
+		res, err := db.lookup("h1:gomodgomodgomodgomodgomodgomodgomodgomodgom=")
+		assert.NilError(t, err)
+		assert.Equal(t, 0, len(res))
+	})
+}
+
+// TestLookupWithExtraFS ensures that Lookup falls back to the extra FS
+// even when the cache directory does not exist (i.e., `update` was never run).
+func TestLookupWithExtraFS(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nonexistent")
+	c, err := New(WithDir(dir), WithExtraFS(newTestFS()))
+	assert.NilError(t, err)
+
+	ctx := t.Context()
+	res, err := c.Lookup(ctx, "h1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=")
+	assert.NilError(t, err)
+	assert.Equal(t, 1, len(res))
+	assert.Equal(t, "foo", res[0].Repo.Owner)
+
+	res, err = c.Lookup(ctx, "h1:ccccccccccccccccccccccccccccccccccccccccccc=")
+	assert.NilError(t, err)
+	assert.Equal(t, 0, len(res))
+
+	_, err = c.Lookup(ctx, "not-an-h1-sum")
+	assert.ErrorContains(t, err, "expected h1 sum")
+}

--- a/pkg/cache/fsdb.go
+++ b/pkg/cache/fsdb.go
@@ -1,0 +1,76 @@
+package cache
+
+import (
+	"bufio"
+	"encoding/json"
+	"io/fs"
+	"path"
+	"strings"
+	"sync"
+)
+
+// fsDB is a read-only database backed by [fs.FS], with the same layout as
+// the cache directory. Unlike the cache directory, which is searched with
+// `git grep`, fsDB is searched with an in-memory index that is lazily built
+// on the first lookup.
+type fsDB struct {
+	fsys   fs.FS
+	once   sync.Once
+	idx    map[string][]string // h1 sum -> directories containing the matching go.sum
+	idxErr error
+}
+
+func (d *fsDB) buildIndex() {
+	d.idx = make(map[string][]string)
+	d.idxErr = fs.WalkDir(d.fsys, ".", func(p string, ent fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if ent.IsDir() || ent.Name() != "go.sum" {
+			return nil
+		}
+		f, err := d.fsys.Open(p)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		dir := path.Dir(p)
+		sc := bufio.NewScanner(f)
+		for sc.Scan() {
+			fields := strings.Fields(sc.Text())
+			if len(fields) != 3 {
+				continue
+			}
+			if strings.HasSuffix(fields[1], "/go.mod") {
+				// Lookup queries the h1 sum of the module zip, not of go.mod
+				continue
+			}
+			sum := fields[2]
+			dirs := d.idx[sum]
+			if len(dirs) == 0 || dirs[len(dirs)-1] != dir {
+				d.idx[sum] = append(dirs, dir)
+			}
+		}
+		return sc.Err()
+	})
+}
+
+func (d *fsDB) lookup(sum string) ([]Meta, error) {
+	d.once.Do(d.buildIndex)
+	if d.idxErr != nil {
+		return nil, d.idxErr
+	}
+	var res []Meta
+	for _, dir := range d.idx[sum] {
+		b, err := fs.ReadFile(d.fsys, path.Join(dir, MetaFilename))
+		if err != nil {
+			return res, err
+		}
+		var m Meta
+		if err = json.Unmarshal(b, &m); err != nil {
+			return res, err
+		}
+		res = append(res, m)
+	}
+	return res, nil
+}

--- a/pkg/embeddeddb/embeddeddb.go
+++ b/pkg/embeddeddb/embeddeddb.go
@@ -1,0 +1,42 @@
+// Package embeddeddb provides the database that was embedded into the binary
+// at build time, so that `gosocialcheck run` can work without running
+// `gosocialcheck update` first.
+//
+// The db directory is periodically updated by the "Update the embedded database"
+// GitHub Actions workflow (.github/workflows/update-db.yml), which runs
+// `gosocialcheck update --dir pkg/embeddeddb/db` and opens a pull request.
+package embeddeddb
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed all:db
+var embedded embed.FS
+
+// FS returns the embedded database, rooted at the db directory.
+// The layout is the same as the cache directory of [github.com/AkihiroSuda/gosocialcheck/pkg/cache].
+func FS() (fs.FS, error) {
+	return fs.Sub(embedded, "db")
+}
+
+// IsEmpty returns true if the embedded database contains no entries,
+// e.g., when the binary was built from a source tree in which the db
+// directory was not populated yet.
+func IsEmpty() (bool, error) {
+	fsys, err := FS()
+	if err != nil {
+		return false, err
+	}
+	ents, err := fs.ReadDir(fsys, ".")
+	if err != nil {
+		return false, err
+	}
+	for _, ent := range ents {
+		if ent.IsDir() {
+			return false, nil
+		}
+	}
+	return true, nil
+}


### PR DESCRIPTION
The database is embedded via `//go:embed` from pkg/embeddeddb/db, which is periodically regenerated by a new GitHub Actions workflow (`gosocialcheck update --dir pkg/embeddeddb/db`) that opens a pull request with the result; it never commits to master directly.

`gosocialcheck run` and `lookup` now fall back to the embedded database when the local cache does not exist yet; when both exist, the lookup results are merged and deduplicated. The embedded database is searched with an in-memory index (built lazily on the first lookup) instead of `git grep`.

Fix #45