### PR TITLE
cache: dedup tags by commit SHA to fix non-deterministic cache

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -193,6 +193,26 @@ func filterPrelease(tags []github.Tag) []github.Tag {
 	return res
 }
 
+// dedupTagsBySHA deduplicates tags that point to the same commit SHA.
+// When multiple tags share a SHA, the one with the lexicographically
+// smallest name is kept, so the result is deterministic regardless of
+// the input order returned by the GitHub API.
+func dedupTagsBySHA(tags []github.Tag) []github.Tag {
+	idx := make(map[string]int, len(tags))
+	res := make([]github.Tag, 0, len(tags))
+	for _, t := range tags {
+		if i, ok := idx[t.Commit.SHA]; ok {
+			if t.Name < res[i].Name {
+				res[i] = t
+			}
+			continue
+		}
+		idx[t.Commit.SHA] = len(res)
+		res = append(res, t)
+	}
+	return res
+}
+
 // updateGitHubRepo expects url to be "https://github.com/<ORG>/<REPO>".
 func (c *Cache) updateGitHubRepo(ctx context.Context, urlStr, category string) error {
 	repo, err := github.NewRepo(urlStr)
@@ -204,6 +224,7 @@ func (c *Cache) updateGitHubRepo(ctx context.Context, urlStr, category string) e
 		return err
 	}
 	tags = filterPrelease(tags)
+	tags = dedupTagsBySHA(tags)
 	const maxTags = 10
 	if len(tags) > maxTags {
 		tags = tags[:maxTags]

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,0 +1,82 @@
+package cache
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/AkihiroSuda/gosocialcheck/pkg/netutil/github"
+)
+
+func tagWithSHA(name, sha string) github.Tag {
+	var t github.Tag
+	t.Name = name
+	t.Commit.SHA = sha
+	return t
+}
+
+func TestDedupTagsBySHA(t *testing.T) {
+	// https://github.com/AkihiroSuda/gosocialcheck/issues/64
+	// Multiple Falco component tags share a single commit SHA;
+	// the cache must pick the same tag deterministically across runs.
+	const sharedSHA = "323213fe0f87ceb825c29c9e8094439d7f8edb56"
+	cases := []struct {
+		name string
+		in   []github.Tag
+		want []github.Tag
+	}{
+		{
+			name: "no duplicates",
+			in: []github.Tag{
+				tagWithSHA("v1.0.0", "aaa"),
+				tagWithSHA("v0.9.0", "bbb"),
+			},
+			want: []github.Tag{
+				tagWithSHA("v1.0.0", "aaa"),
+				tagWithSHA("v0.9.0", "bbb"),
+			},
+		},
+		{
+			name: "shared SHA keeps lexicographically smallest name",
+			in: []github.Tag{
+				tagWithSHA("agent/0.84.3", sharedSHA),
+				tagWithSHA("agent/0.84.1", sharedSHA),
+				tagWithSHA("agent/0.84.2", sharedSHA),
+			},
+			want: []github.Tag{
+				tagWithSHA("agent/0.84.1", sharedSHA),
+			},
+		},
+		{
+			name: "deterministic regardless of input order",
+			in: []github.Tag{
+				tagWithSHA("agent/0.84.1", sharedSHA),
+				tagWithSHA("agent/0.84.3", sharedSHA),
+				tagWithSHA("agent/0.84.2", sharedSHA),
+			},
+			want: []github.Tag{
+				tagWithSHA("agent/0.84.1", sharedSHA),
+			},
+		},
+		{
+			name: "preserves first-occurrence order across distinct SHAs",
+			in: []github.Tag{
+				tagWithSHA("v1.0.0", "aaa"),
+				tagWithSHA("v0.9.1", "bbb"),
+				tagWithSHA("v0.9.0", "bbb"),
+				tagWithSHA("v0.8.0", "ccc"),
+			},
+			want: []github.Tag{
+				tagWithSHA("v1.0.0", "aaa"),
+				tagWithSHA("v0.9.0", "bbb"),
+				tagWithSHA("v0.8.0", "ccc"),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dedupTagsBySHA(tc.in)
+			assert.DeepEqual(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Multiple tags can share a commit SHA (e.g. falcosecurity/falco's agent/0.84.{1,2,3}). With one goroutine per tag, they raced to write the same gosocialcheck-meta.json, so the recorded tag varied across runs. Dedup by SHA before fan-out, deterministically keeping the lexicographically smallest tag name.

Fixes #64