### PR TITLE
cache: add remote cache fetched from gosocialcheck-cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,28 @@ require (
 
 Note: The directive ignores the module version.
 
+### Cache
+
+`gosocialcheck` keeps two cache flavors under `$XDG_CACHE_HOME/gosocialcheck`
+(`~/Library/Caches/gosocialcheck` on macOS):
+
+- `_remote`: a shallow clone of [`AkihiroSuda/gosocialcheck-cache`](https://github.com/AkihiroSuda/gosocialcheck-cache),
+  preprocessed and ready to use.
+- `_local`: rebuilt locally from the CNCF project list and the GitHub API
+  (`gosocialcheck update --cache-mode=local`).
+
+The `--cache-mode` flag (or `$GOSOCIALCHECK_CACHE_MODE`) selects which one is used:
+
+- `auto` (default): for reads, picks whichever has the more recent `ModTime`.
+  For `update`, fetches the remote.
+- `remote`: use the preprocessed remote cache.
+- `local`: rebuild and use the local cache.
+
+`gosocialcheck run` populates the cache automatically on the first run.
+
+Run `gosocialcheck info` (or `gosocialcheck info --json`) to inspect the
+current cache state.
+
 ### GitHub API rate limit
 gosocialcheck uses the GitHub API for the following operations:
 - Fetch git tags, via `api.github.com`.

--- a/cmd/gosocialcheck/cacheopt/cacheopt.go
+++ b/cmd/gosocialcheck/cacheopt/cacheopt.go
@@ -1,0 +1,21 @@
+// Package cacheopt resolves the persistent --cache-mode flag into a
+// [cache.Opt] slice that can be passed to [cache.New].
+package cacheopt
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/AkihiroSuda/gosocialcheck/pkg/cache"
+)
+
+// FromCommand reads the persistent --cache-mode flag from cmd and returns
+// the matching [cache.Opt]s.
+func FromCommand(cmd *cobra.Command) ([]cache.Opt, error) {
+	flags := cmd.Flags()
+	cacheMode, _ := flags.GetString("cache-mode")
+	mode, err := cache.ParseMode(cacheMode)
+	if err != nil {
+		return nil, err
+	}
+	return []cache.Opt{cache.WithMode(mode)}, nil
+}

--- a/cmd/gosocialcheck/commands/info/info.go
+++ b/cmd/gosocialcheck/commands/info/info.go
@@ -1,0 +1,61 @@
+package info
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck/cacheopt"
+	"github.com/AkihiroSuda/gosocialcheck/pkg/cache"
+)
+
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "info",
+		Short:                 "Show cache info",
+		Args:                  cobra.NoArgs,
+		RunE:                  action,
+		DisableFlagsInUseLine: true,
+	}
+	flags := cmd.Flags()
+	flags.Bool("json", false, "JSON output")
+	return cmd
+}
+
+func action(cmd *cobra.Command, args []string) error {
+	flags := cmd.Flags()
+	jsonOut, _ := flags.GetBool("json")
+	cacheOpts, err := cacheopt.FromCommand(cmd)
+	if err != nil {
+		return err
+	}
+	c, err := cache.New(cacheOpts...)
+	if err != nil {
+		return err
+	}
+	s := c.Status()
+	w := cmd.OutOrStdout()
+	if jsonOut {
+		enc := json.NewEncoder(w)
+		enc.SetEscapeHTML(false)
+		enc.SetIndent("", "  ")
+		return enc.Encode(s)
+	}
+	fmt.Fprintf(w, "Cache mode:     %s\n", s.Mode)
+	fmt.Fprintln(w, "Local:")
+	fmt.Fprintf(w, "  Path:         %s\n", s.Local.Dir)
+	fmt.Fprintf(w, "  Exists:       %t\n", s.Local.Exists)
+	if !s.Local.LastUpdated.IsZero() {
+		fmt.Fprintf(w, "  Last updated: %s\n", s.Local.LastUpdated.Format(time.RFC3339))
+	}
+	fmt.Fprintln(w, "Remote:")
+	fmt.Fprintf(w, "  URL:          %s\n", s.Remote.URL)
+	fmt.Fprintf(w, "  Path:         %s\n", s.Remote.Dir)
+	fmt.Fprintf(w, "  Exists:       %t\n", s.Remote.Exists)
+	if !s.Remote.LastUpdated.IsZero() {
+		fmt.Fprintf(w, "  Last updated: %s\n", s.Remote.LastUpdated.Format(time.RFC3339))
+	}
+	return nil
+}

--- a/cmd/gosocialcheck/commands/lookup/lookup.go
+++ b/cmd/gosocialcheck/commands/lookup/lookup.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck/cacheopt"
 	"github.com/AkihiroSuda/gosocialcheck/pkg/cache"
 )
 
@@ -22,7 +23,11 @@ func New() *cobra.Command {
 func action(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	sum := args[0]
-	c, err := cache.New()
+	cacheOpts, err := cacheopt.FromCommand(cmd)
+	if err != nil {
+		return err
+	}
+	c, err := cache.New(cacheOpts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/gosocialcheck/commands/run/run.go
+++ b/cmd/gosocialcheck/commands/run/run.go
@@ -1,11 +1,14 @@
 package run
 
 import (
+	"context"
+	"log/slog"
 	"os"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/tools/go/analysis/singlechecker"
 
+	"github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck/cacheopt"
 	"github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck/flagutil"
 	"github.com/AkihiroSuda/gosocialcheck/pkg/analyzer"
 	"github.com/AkihiroSuda/gosocialcheck/pkg/cache"
@@ -32,15 +35,23 @@ func action(cmd *cobra.Command, args []string) error {
 	os.Args = append([]string{"gosocialcheck-run"}, args...)
 
 	ctx := cmd.Context()
-	c, err := cache.New()
+	cacheOpts, err := cacheopt.FromCommand(cmd)
 	if err != nil {
 		return err
 	}
-	if _, err = c.LastUpdated(); err != nil {
+	onProgress := func(ctx context.Context, ev cache.ProgressEvent) {
+		slog.InfoContext(ctx, "progress: "+ev.Message)
+	}
+	cacheOpts = append(cacheOpts, cache.WithProgressEventHandler(onProgress))
+	c, err := cache.New(cacheOpts...)
+	if err != nil {
+		return err
+	}
+	if err = c.EnsureUpdated(ctx); err != nil {
 		return err
 	}
 	flags := cmd.Flags()
-	goflags := flagutil.PFlagSetToGoFlagSet(flags, []string{"debug"})
+	goflags := flagutil.PFlagSetToGoFlagSet(flags, []string{"debug", "cache-mode"})
 	if err := goflags.Parse(args); err != nil {
 		return err
 	}

--- a/cmd/gosocialcheck/commands/update/update.go
+++ b/cmd/gosocialcheck/commands/update/update.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck/cacheopt"
 	"github.com/AkihiroSuda/gosocialcheck/pkg/cache"
 )
 
@@ -17,6 +18,9 @@ func New() *cobra.Command {
 		RunE:                  action,
 		DisableFlagsInUseLine: true,
 	}
+	flags := cmd.Flags()
+	flags.String("cache-remote", cache.DefaultRemoteURL,
+		"URL of the remote cache repository")
 	return cmd
 }
 
@@ -25,7 +29,16 @@ func action(cmd *cobra.Command, args []string) error {
 	onProgress := func(ctx context.Context, ev cache.ProgressEvent) {
 		slog.InfoContext(ctx, "progress: "+ev.Message)
 	}
-	c, err := cache.New(cache.WithProgressEventHandler(onProgress))
+	cacheOpts, err := cacheopt.FromCommand(cmd)
+	if err != nil {
+		return err
+	}
+	cacheRemote, _ := cmd.Flags().GetString("cache-remote")
+	cacheOpts = append(cacheOpts,
+		cache.WithRemoteURL(cacheRemote),
+		cache.WithProgressEventHandler(onProgress),
+	)
+	c, err := cache.New(cacheOpts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/gosocialcheck/envutil/envutil.go
+++ b/cmd/gosocialcheck/envutil/envutil.go
@@ -9,6 +9,13 @@ import (
 	"log/slog"
 )
 
+func String(envName, defaultValue string) string {
+	if v, ok := os.LookupEnv(envName); ok {
+		return v
+	}
+	return defaultValue
+}
+
 func Bool(envName string, defaultValue bool) bool {
 	v, ok := os.LookupEnv(envName)
 	if !ok {

--- a/cmd/gosocialcheck/main.go
+++ b/cmd/gosocialcheck/main.go
@@ -8,11 +8,13 @@ import (
 	"github.com/lmittmann/tint"
 	"github.com/spf13/cobra"
 
+	"github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck/commands/info"
 	"github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck/commands/lookup"
 	"github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck/commands/run"
 	"github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck/commands/update"
 	"github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck/envutil"
 	"github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck/version"
+	"github.com/AkihiroSuda/gosocialcheck/pkg/cache"
 )
 
 var logLevel = new(slog.LevelVar)
@@ -52,10 +54,17 @@ func newRootCommand() *cobra.Command {
 
 	flags := cmd.PersistentFlags()
 	flags.Bool("debug", envutil.Bool("DEBUG", false), "debug mode [$DEBUG]")
+	flags.String("cache-mode",
+		envutil.String("GOSOCIALCHECK_CACHE_MODE", string(cache.ModeAuto)),
+		`cache mode ("auto", "remote", or "local") [$GOSOCIALCHECK_CACHE_MODE]`)
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		flags := cmd.Flags()
 		if debug, _ := flags.GetBool("debug"); debug {
 			logLevel.Set(slog.LevelDebug)
+		}
+		cacheMode, _ := flags.GetString("cache-mode")
+		if _, err := cache.ParseMode(cacheMode); err != nil {
+			return err
 		}
 		return nil
 	}
@@ -64,6 +73,7 @@ func newRootCommand() *cobra.Command {
 		update.New(),
 		lookup.New(),
 		run.New(),
+		info.New(),
 	)
 	return cmd
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -4,14 +4,16 @@
 TODO: consider switching to bbolt
 
 ~/.cache: the cache home ($XDG_CACHE_HOME)
-  gosocialcheck: the ModTime represents the last updated time
-    github.com
-      containerd
+  gosocialcheck
+    _local: rebuilt from upstream sources (CNCF + GitHub APIs)
+      github.com
         containerd
-         fb4c30d4ede3531652d86197bf3fc9515e5276d9
-           gosocialcheck-cache.json
-           go.mod
-           go.sum
+          containerd
+           fb4c30d4ede3531652d86197bf3fc9515e5276d9
+             gosocialcheck-meta.json
+             go.mod
+             go.sum
+    _remote: shallow clone of the preprocessed cache repository
 */
 
 package cache
@@ -43,6 +45,38 @@ import (
 	"github.com/AkihiroSuda/gosocialcheck/pkg/source/cncf"
 )
 
+// Mode selects which cache flavor to use.
+type Mode string
+
+const (
+	// ModeAuto picks remote/local automatically based on which is newer
+	// for read operations; for [Cache.Update] it acts as ModeRemote.
+	ModeAuto Mode = "auto"
+	// ModeRemote uses the cache fetched from [DefaultRemoteURL].
+	ModeRemote Mode = "remote"
+	// ModeLocal uses the cache rebuilt locally from upstream sources.
+	ModeLocal Mode = "local"
+)
+
+// ParseMode validates s and returns the corresponding [Mode].
+func ParseMode(s string) (Mode, error) {
+	m := Mode(s)
+	switch m {
+	case ModeAuto, ModeRemote, ModeLocal:
+		return m, nil
+	}
+	return "", fmt.Errorf("invalid cache mode %q (must be %q, %q, or %q)",
+		s, ModeAuto, ModeRemote, ModeLocal)
+}
+
+const (
+	localDirName  = "_local"
+	remoteDirName = "_remote"
+
+	// DefaultRemoteURL is the default URL for the remote cache repository.
+	DefaultRemoteURL = "https://github.com/AkihiroSuda/gosocialcheck-cache.git"
+)
+
 type ProgressEvent struct {
 	Message string `json:"message,omitempty"`
 }
@@ -55,6 +89,8 @@ func DefaultProgressEventHandler(ctx context.Context, ev ProgressEvent) {
 
 type opts struct {
 	dir        string
+	mode       Mode
+	remoteURL  string
 	onProgress ProgressEventHandler
 	httpClient *http.Client
 }
@@ -64,6 +100,29 @@ type Opt func(*opts) error
 func WithDir(dir string) Opt {
 	return func(opts *opts) error {
 		opts.dir = dir
+		return nil
+	}
+}
+
+func WithMode(mode Mode) Opt {
+	return func(opts *opts) error {
+		if mode == "" {
+			return nil
+		}
+		if _, err := ParseMode(string(mode)); err != nil {
+			return err
+		}
+		opts.mode = mode
+		return nil
+	}
+}
+
+func WithRemoteURL(url string) Opt {
+	return func(opts *opts) error {
+		if url == "" {
+			return nil
+		}
+		opts.remoteURL = url
 		return nil
 	}
 }
@@ -97,6 +156,12 @@ func New(o ...Opt) (*Cache, error) {
 		}
 		c.opts.dir = filepath.Join(cacheHome, "gosocialcheck")
 	}
+	if c.opts.mode == "" {
+		c.opts.mode = ModeAuto
+	}
+	if c.opts.remoteURL == "" {
+		c.opts.remoteURL = DefaultRemoteURL
+	}
 	if c.opts.onProgress == nil {
 		c.opts.onProgress = DefaultProgressEventHandler
 	}
@@ -108,7 +173,6 @@ func New(o ...Opt) (*Cache, error) {
 
 type Cache struct {
 	opts
-	updated []string
 }
 
 func (c *Cache) httpOpts() []netutil.HTTPOpt {
@@ -118,18 +182,142 @@ func (c *Cache) httpOpts() []netutil.HTTPOpt {
 	}
 }
 
-// LastUpdated returns the last updated time.
-// LastUpdated returns [fs.ErrNotExist] on the first run.
-func (c *Cache) LastUpdated() (time.Time, error) {
-	st, err := os.Stat(c.dir)
+// LocalDir is the directory of the locally rebuilt cache.
+func (c *Cache) LocalDir() string {
+	return filepath.Join(c.dir, localDirName)
+}
+
+// RemoteDir is the directory of the cache fetched from the remote.
+func (c *Cache) RemoteDir() string {
+	return filepath.Join(c.dir, remoteDirName)
+}
+
+// ReadMode returns the mode used for read operations.
+// It is either [ModeLocal] or [ModeRemote]; [ModeAuto] is resolved
+// to whichever of local/remote has the more recent ModTime.
+func (c *Cache) ReadMode() Mode {
+	if c.opts.mode != ModeAuto {
+		return c.opts.mode
+	}
+	localT, lErr := modTime(c.LocalDir())
+	remoteT, rErr := modTime(c.RemoteDir())
+	switch {
+	case lErr != nil && rErr != nil:
+		// Neither exists. Default to local so LastUpdated surfaces
+		// the canonical "please run `gosocialcheck update`" error.
+		return ModeLocal
+	case lErr != nil:
+		return ModeRemote
+	case rErr != nil:
+		return ModeLocal
+	case remoteT.After(localT):
+		return ModeRemote
+	default:
+		return ModeLocal
+	}
+}
+
+// dataDir returns the directory to read cached data from.
+func (c *Cache) dataDir() string {
+	if c.ReadMode() == ModeRemote {
+		return c.RemoteDir()
+	}
+	return c.LocalDir()
+}
+
+func modTime(dir string) (time.Time, error) {
+	st, err := os.Stat(dir)
 	if err != nil {
 		return time.Time{}, err
 	}
 	return st.ModTime(), nil
 }
 
-// Update updates the cache.
+// LastUpdated returns the last updated time of the cache selected by [Cache.ReadMode].
+// LastUpdated returns [fs.ErrNotExist] on the first run.
+func (c *Cache) LastUpdated() (time.Time, error) {
+	return modTime(c.dataDir())
+}
+
+// EnsureUpdated populates the cache if it has not been updated yet.
+// Otherwise it is a no-op.
+func (c *Cache) EnsureUpdated(ctx context.Context) error {
+	if _, err := c.LastUpdated(); err == nil {
+		return nil
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return c.Update(ctx)
+}
+
+// SubStatus describes the state of a single cache flavor.
+type SubStatus struct {
+	Dir         string    `json:"dir"`
+	Exists      bool      `json:"exists"`
+	LastUpdated time.Time `json:"last_updated,omitzero"`
+}
+
+// RemoteStatus extends [SubStatus] with the configured remote URL.
+type RemoteStatus struct {
+	SubStatus
+	URL string `json:"url"`
+}
+
+// Status reports the cache status.
+type Status struct {
+	// Mode is the configured cache mode (auto/remote/local).
+	Mode   Mode         `json:"mode"`
+	Local  SubStatus    `json:"local"`
+	Remote RemoteStatus `json:"remote"`
+}
+
+// Status returns the current cache status.
+func (c *Cache) Status() *Status {
+	s := &Status{
+		Mode: c.opts.mode,
+		Local: SubStatus{
+			Dir: c.LocalDir(),
+		},
+		Remote: RemoteStatus{
+			SubStatus: SubStatus{
+				Dir: c.RemoteDir(),
+			},
+			URL: c.opts.remoteURL,
+		},
+	}
+	if t, err := modTime(c.LocalDir()); err == nil {
+		s.Local.Exists = true
+		s.Local.LastUpdated = t
+	}
+	if t, err := modTime(c.RemoteDir()); err == nil {
+		s.Remote.Exists = true
+		s.Remote.LastUpdated = t
+	}
+	return s
+}
+
+// Update updates the cache. The target is determined by the configured mode:
+// [ModeLocal] rebuilds from upstream sources, [ModeRemote] fetches the latest
+// preprocessed cache, and [ModeAuto] is treated as [ModeRemote] (the recommended path).
 func (c *Cache) Update(ctx context.Context) error {
+	mode := c.opts.mode
+	if mode == ModeAuto {
+		mode = ModeRemote
+	}
+	switch mode {
+	case ModeLocal:
+		return c.updateLocal(ctx)
+	case ModeRemote:
+		return c.updateRemote(ctx)
+	}
+	return fmt.Errorf("unsupported cache mode for update: %q", mode)
+}
+
+func (c *Cache) updateLocal(ctx context.Context) error {
+	dir := c.LocalDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
 	b, err := netutil.Get(ctx, cncf.ProjectsURL, c.httpOpts()...)
 	if err != nil {
 		return err
@@ -143,13 +331,53 @@ func (c *Cache) Update(ctx context.Context) error {
 			return err
 		}
 	}
-	if len(c.updated) > 0 {
-		now := time.Now()
-		if err = os.Chtimes(c.dir, now, now); err != nil {
-			return err
-		}
+	now := time.Now()
+	if err = os.Chtimes(dir, now, now); err != nil {
+		return err
 	}
 	return nil
+}
+
+func (c *Cache) updateRemote(ctx context.Context) error {
+	dir := c.RemoteDir()
+	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
+		return err
+	}
+	gitDir := filepath.Join(dir, ".git")
+	_, statErr := os.Stat(gitDir)
+	switch {
+	case errors.Is(statErr, fs.ErrNotExist):
+		c.onProgress(ctx, ProgressEvent{Message: "cloning " + c.opts.remoteURL})
+		args := []string{"clone", "--depth", "1", c.opts.remoteURL, dir}
+		if out, err := runGit(ctx, "", args...); err != nil {
+			return fmt.Errorf("git clone failed: %w: %s", err, out)
+		}
+	case statErr != nil:
+		return statErr
+	default:
+		c.onProgress(ctx, ProgressEvent{Message: "fetching " + c.opts.remoteURL})
+		if out, err := runGit(ctx, dir, "fetch", "--depth", "1", "origin"); err != nil {
+			return fmt.Errorf("git fetch failed: %w: %s", err, out)
+		}
+		if out, err := runGit(ctx, dir, "reset", "--hard", "FETCH_HEAD"); err != nil {
+			return fmt.Errorf("git reset failed: %w: %s", err, out)
+		}
+	}
+	now := time.Now()
+	if err := os.Chtimes(dir, now, now); err != nil {
+		return err
+	}
+	return nil
+}
+
+func runGit(ctx context.Context, dir string, args ...string) (string, error) {
+	full := args
+	if dir != "" {
+		full = append([]string{"-C", dir}, args...)
+	}
+	cmd := exec.CommandContext(ctx, "git", full...)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
 }
 
 func (c *Cache) updateCNCFProject(ctx context.Context, p cncf.Project) error {
@@ -239,7 +467,7 @@ func (c *Cache) updateGitHubRepo(ctx context.Context, urlStr, category string) e
 }
 
 func (c *Cache) updateGitHubRepoTag(ctx context.Context, repo *github.Repo, tag github.Tag, category string) error {
-	dir := filepath.Join(c.dir, "github.com", repo.Owner, repo.Repo, tag.Commit.SHA)
+	dir := filepath.Join(c.LocalDir(), "github.com", repo.Owner, repo.Repo, tag.Commit.SHA)
 	if _, err := os.Stat(dir); !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
@@ -295,13 +523,14 @@ func (c *Cache) Lookup(ctx context.Context, sum string) ([]Meta, error) {
 	if !strings.HasPrefix(sum, "h1:") || !strings.HasSuffix(sum, "=") {
 		return nil, fmt.Errorf("expected h1 sum, got %q", sum)
 	}
-	goSumFiles, err := c.lookupGoSumFiles(ctx, sum)
+	dataDir := c.dataDir()
+	goSumFiles, err := c.lookupGoSumFiles(ctx, dataDir, sum)
 	if err != nil {
 		return nil, err
 	}
 	var res []Meta
 	for _, goSumFile := range goSumFiles {
-		dir := filepath.Join(c.dir, filepath.Clean(filepath.Dir(goSumFile)))
+		dir := filepath.Join(dataDir, filepath.Clean(filepath.Dir(goSumFile)))
 		f := filepath.Join(dir, MetaFilename)
 		b, err := os.ReadFile(f)
 		if err != nil {
@@ -316,9 +545,17 @@ func (c *Cache) Lookup(ctx context.Context, sum string) ([]Meta, error) {
 	return res, nil
 }
 
-func (c *Cache) lookupGoSumFiles(ctx context.Context, sum string) ([]string, error) {
+func (c *Cache) lookupGoSumFiles(ctx context.Context, dataDir, sum string) ([]string, error) {
 	var stdout, stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, "git", "-C", c.dir, "grep", "--name-only", "--no-index", sum)
+	// The remote cache directory is a real git working tree, so plain
+	// `git grep` confines the search to tracked files (and skips .git/).
+	// The local cache directory is not a git repo, so we need --no-index.
+	args := []string{"-C", dataDir, "grep", "--name-only"}
+	if c.ReadMode() == ModeLocal {
+		args = append(args, "--no-index")
+	}
+	args = append(args, sum)
+	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Add a `--cache-mode` flag (`auto`/`remote`/`local`, also `$GOSOCIALCHECK_CACHE_MODE`) and split the cache directory into `_local/` (rebuilt from CNCF + GitHub APIs) and `_remote/` (shallow clone of https://github.com/AkihiroSuda/gosocialcheck-cache).

In `auto` mode, reads pick whichever side has the more recent `ModTime`, and `update` fetches the remote. `gosocialcheck run` populates the cache automatically the first time it is invoked.

Also add `gosocialcheck info` (`--json`) to inspect the configured cache mode along with each flavor's path and last-updated time.

Fixes #63