### PR TITLE
analyzer: in --gha mode, only check go.sum lines changed in a PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,16 @@ import 'github.com/lmittmann/tint': module 'github.com/lmittmann/tint@v1.0.7' do
 
 Pass `--gha` to emit findings as
 [workflow commands](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands)
-so they show up as annotations on the workflow run and any associated PR.
+so they show up as annotations ([up to 10](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md#limitations)) on the workflow run and any associated PR.
 In this mode the command always exits 0.
 
+To stay within GitHub's annotation limits, `--gha` caps the number of emitted
+annotations and reports findings whose `go.sum` line changed in the PR first. On
+a `pull_request` event it fetches the base branch (`GITHUB_BASE_REF`) on demand
+to detect those lines, so the default shallow checkout works as-is:
+
 ```yaml
+- uses: actions/checkout@v4
 - run: go install github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck@latest
 - run: gosocialcheck run --gha ./...
 ```

--- a/cmd/gosocialcheck/commands/run/run.go
+++ b/cmd/gosocialcheck/commands/run/run.go
@@ -59,9 +59,10 @@ func action(cmd *cobra.Command, args []string) error {
 	}
 	goflags := flagutil.PFlagSetToGoFlagSet(flags, []string{"debug", "cache-mode", "gha"})
 	opts := analyzer.Opts{
-		Flags: *goflags,
-		Cache: c,
-		GHA:   gha,
+		Flags:      *goflags,
+		Cache:      c,
+		GHA:        gha,
+		OnProgress: onProgress,
 	}
 	a, err := analyzer.New(ctx, opts)
 	if err != nil {
@@ -81,10 +82,13 @@ func action(cmd *cobra.Command, args []string) error {
 	}
 	pkgErrors := packages.PrintErrors(initial)
 
-	graph, err := checker.Analyze([]*analysis.Analyzer{a}, initial, nil)
+	graph, err := checker.Analyze([]*analysis.Analyzer{a.Analyzer}, initial, nil)
 	if err != nil {
 		return err
 	}
+	// In --gha mode findings are buffered during analysis; emit them now,
+	// prioritized and capped to fit GitHub's annotation limit.
+	a.Flush(ctx)
 	if err := graph.PrintText(os.Stderr, -1); err != nil {
 		return err
 	}

--- a/cmd/gosocialcheck/commands/run/run.go
+++ b/cmd/gosocialcheck/commands/run/run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck/flagutil"
 	"github.com/AkihiroSuda/gosocialcheck/pkg/analyzer"
 	"github.com/AkihiroSuda/gosocialcheck/pkg/cache"
+	"github.com/AkihiroSuda/gosocialcheck/pkg/progress"
 )
 
 func New() *cobra.Command {
@@ -40,7 +41,7 @@ func action(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	onProgress := func(ctx context.Context, ev cache.ProgressEvent) {
+	onProgress := func(ctx context.Context, ev progress.Event) {
 		slog.InfoContext(ctx, "progress: "+ev.Message)
 	}
 	cacheOpts = append(cacheOpts, cache.WithProgressEventHandler(onProgress))

--- a/cmd/gosocialcheck/commands/update/update.go
+++ b/cmd/gosocialcheck/commands/update/update.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/AkihiroSuda/gosocialcheck/cmd/gosocialcheck/cacheopt"
 	"github.com/AkihiroSuda/gosocialcheck/pkg/cache"
+	"github.com/AkihiroSuda/gosocialcheck/pkg/progress"
 )
 
 func New() *cobra.Command {
@@ -26,7 +27,7 @@ func New() *cobra.Command {
 
 func action(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	onProgress := func(ctx context.Context, ev cache.ProgressEvent) {
+	onProgress := func(ctx context.Context, ev progress.Event) {
 		slog.InfoContext(ctx, "progress: "+ev.Message)
 	}
 	cacheOpts, err := cacheopt.FromCommand(cmd)

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -11,7 +11,10 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -22,6 +25,7 @@ import (
 	"golang.org/x/tools/go/analysis"
 
 	"github.com/AkihiroSuda/gosocialcheck/pkg/cache"
+	"github.com/AkihiroSuda/gosocialcheck/pkg/progress"
 )
 
 type Opts struct {
@@ -32,6 +36,9 @@ type Opts struct {
 	// when there are findings. See:
 	// https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands
 	GHA bool
+	// OnProgress, if set, receives progress events (e.g. while fetching the base
+	// branch in --gha mode).
+	OnProgress progress.Handler
 }
 
 const (
@@ -39,15 +46,32 @@ const (
 	directivePolicyTrusted   = "trusted"
 )
 
-func New(ctx context.Context, opts Opts) (*analysis.Analyzer, error) {
+// Analyzer wraps an [analysis.Analyzer]. In --gha mode diagnostics are buffered
+// rather than emitted during analysis; the caller must invoke [Analyzer.Flush]
+// once analysis has completed to write the (prioritized and capped) workflow
+// commands. Outside --gha mode Flush is a no-op.
+type Analyzer struct {
+	*analysis.Analyzer
+	inst *instance
+}
+
+// Flush emits the buffered --gha findings. It must be called after analysis has
+// completed. It is a no-op outside --gha mode.
+func (a *Analyzer) Flush(ctx context.Context) {
+	a.inst.flushGHA(ctx)
+}
+
+func New(ctx context.Context, opts Opts) (*Analyzer, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, err
 	}
 	inst := &instance{
-		Opts:          opts,
-		processedSums: make(map[string]struct{}),
-		cwd:           cwd,
+		Opts:                opts,
+		processedSums:       make(map[string]struct{}),
+		cwd:                 cwd,
+		changedSumLines:     make(map[string]map[int]struct{}),
+		changedSumLinesDone: make(map[string]bool),
 	}
 	a := &analysis.Analyzer{
 		Name:             "gosocialcheck",
@@ -57,7 +81,7 @@ func New(ctx context.Context, opts Opts) (*analysis.Analyzer, error) {
 		Run:              run(ctx, inst),
 		RunDespiteErrors: false,
 	}
-	return a, nil
+	return &Analyzer{Analyzer: a, inst: inst}, nil
 }
 
 type instance struct {
@@ -65,6 +89,25 @@ type instance struct {
 	processedSums   map[string]struct{}
 	processedSumsMu sync.RWMutex
 	cwd             string
+
+	// changedSumLines caches, per go.sum file, the set of 1-based line numbers
+	// added or modified in the current pull request. changedSumLinesDone records
+	// whether the computation has run (a nil set with done=true means the change
+	// set could not be determined, so no finding is treated as PR-changed).
+	changedSumLinesMu   sync.Mutex
+	changedSumLines     map[string]map[int]struct{}
+	changedSumLinesDone map[string]bool
+
+	// ghaFindings buffers findings in --gha mode so they can be prioritized and
+	// capped before being emitted by flushGHA.
+	ghaFindingsMu sync.Mutex
+	ghaFindings   []ghaFinding
+}
+
+type ghaFinding struct {
+	msg         string
+	sumPosn     token.Position // go.sum line to annotate
+	changedInPR bool           // go.sum line was added/changed in the pull request
 }
 
 func run(ctx context.Context, inst *instance) func(*analysis.Pass) (any, error) {
@@ -142,17 +185,24 @@ func run(ctx context.Context, inst *instance) func(*analysis.Pass) (any, error) 
 						"(negligible if you trust the module)",
 						p, modV.String())
 					if inst.Opts.GHA {
-						emitGHAWarning(inst.cwd,
-							pass.Fset.Position(imp.Pos()),
-							pass.Fset.Position(imp.End()),
-							msg)
+						// Annotate the go.sum line only. If the module has no
+						// go.sum entry there is nothing to annotate.
 						if goSumE.Line > 0 {
-							sumPosn := token.Position{
-								Filename: goSumFilename,
-								Line:     goSumE.Line,
-								Column:   1,
+							f := ghaFinding{
+								msg: msg,
+								sumPosn: token.Position{
+									Filename: goSumFilename,
+									Line:     goSumE.Line,
+									Column:   1,
+								},
 							}
-							emitGHAWarning(inst.cwd, sumPosn, sumPosn, msg)
+							if changed, ok := inst.changedGoSumLines(ctx, goSumFilename); ok {
+								_, f.changedInPR = changed[goSumE.Line]
+							}
+							inst.addGHAFinding(f)
+						} else {
+							slog.DebugContext(ctx, "no go.sum line for module; skipping GHA annotation",
+								"path", p, "modpath", modV.Path)
 						}
 					} else {
 						pass.Report(analysis.Diagnostic{
@@ -168,6 +218,151 @@ func run(ctx context.Context, inst *instance) func(*analysis.Pass) (any, error) 
 		}
 		return nil, nil
 	}
+}
+
+// ghaMaxAnnotations bounds how many GitHub Actions annotations --gha emits, to
+// stay within GitHub's per-run limit (50). Findings whose go.sum line changed in
+// the pull request are emitted first, so the most relevant ones survive the cap.
+const ghaMaxAnnotations = 50
+
+func (inst *instance) addGHAFinding(f ghaFinding) {
+	inst.ghaFindingsMu.Lock()
+	inst.ghaFindings = append(inst.ghaFindings, f)
+	inst.ghaFindingsMu.Unlock()
+}
+
+func (inst *instance) flushGHA(ctx context.Context) {
+	if !inst.Opts.GHA {
+		return
+	}
+	inst.ghaFindingsMu.Lock()
+	findings := inst.ghaFindings
+	inst.ghaFindings = nil
+	inst.ghaFindingsMu.Unlock()
+
+	// Deterministic order regardless of how passes were scheduled: PR-changed
+	// findings first, then by go.sum line and message.
+	sort.SliceStable(findings, func(i, j int) bool {
+		a, b := findings[i], findings[j]
+		if a.changedInPR != b.changedInPR {
+			return a.changedInPR
+		}
+		if a.sumPosn.Line != b.sumPosn.Line {
+			return a.sumPosn.Line < b.sumPosn.Line
+		}
+		return a.msg < b.msg
+	})
+
+	shown := len(findings)
+	if shown > ghaMaxAnnotations {
+		shown = ghaMaxAnnotations
+	}
+	for _, f := range findings[:shown] {
+		emitGHAWarning(inst.cwd, f.sumPosn, f.sumPosn, f.msg)
+	}
+	if shown < len(findings) {
+		slog.WarnContext(ctx, "suppressed findings to stay within the GitHub Actions annotation limit",
+			"shown", shown, "total", len(findings), "limit", ghaMaxAnnotations)
+	}
+}
+
+// changedGoSumLines returns the set of 1-based line numbers in goSumFilename
+// that were added or modified in the current pull request. The second return
+// value reports whether the change set was determined: it is false when not
+// running on a pull_request event or when the diff could not be computed, in
+// which case no finding is treated as PR-changed. The result is computed once
+// per file and cached.
+func (inst *instance) changedGoSumLines(ctx context.Context, goSumFilename string) (map[int]struct{}, bool) {
+	inst.changedSumLinesMu.Lock()
+	defer inst.changedSumLinesMu.Unlock()
+	if inst.changedSumLinesDone[goSumFilename] {
+		set := inst.changedSumLines[goSumFilename]
+		return set, set != nil
+	}
+	set := inst.computeChangedGoSumLines(ctx, goSumFilename)
+	inst.changedSumLinesDone[goSumFilename] = true
+	inst.changedSumLines[goSumFilename] = set
+	return set, set != nil
+}
+
+func (inst *instance) progress(ctx context.Context, msg string) {
+	if inst.Opts.OnProgress != nil {
+		inst.Opts.OnProgress(ctx, progress.Event{Message: msg})
+	}
+}
+
+func (inst *instance) computeChangedGoSumLines(ctx context.Context, goSumFilename string) map[int]struct{} {
+	baseRef := os.Getenv("GITHUB_BASE_REF")
+	if baseRef == "" {
+		// Not a pull_request event; nothing is treated as PR-changed.
+		return nil
+	}
+	dir := filepath.Dir(goSumFilename)
+	base := filepath.Base(goSumFilename)
+	// actions/checkout makes a shallow clone that omits the base branch, so fetch
+	// its tip on demand (into FETCH_HEAD) instead of requiring fetch-depth: 0.
+	inst.progress(ctx, fmt.Sprintf("fetching the base ref %q", baseRef))
+	if out, err := runGit(ctx, dir, "fetch", "--no-tags", "--depth=1", "origin", baseRef); err != nil {
+		slog.WarnContext(ctx, "could not fetch base branch for --gha; not prioritizing PR-changed go.sum lines",
+			"baseRef", baseRef, "error", err, "output", out)
+		return nil
+	}
+	// Diff the fetched base tip against the working tree, so the reported line
+	// numbers match the go.sum the analyzer read.
+	out, err := runGitDiff(ctx, dir, "FETCH_HEAD", base)
+	if err != nil {
+		slog.WarnContext(ctx, "could not diff go.sum against base branch for --gha",
+			"baseRef", baseRef, "error", err)
+		return nil
+	}
+	return parseDiffNewLines(out)
+}
+
+func runGit(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func runGitDiff(ctx context.Context, dir, base, path string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "diff", "--unified=0", "--no-color", base, "--", path)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), nil
+}
+
+// hunkHeaderRe matches unified-diff hunk headers, capturing the new-side start
+// line and optional line count, e.g. "@@ -1,2 +3,4 @@".
+var hunkHeaderRe = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`)
+
+func parseDiffNewLines(diff string) map[int]struct{} {
+	res := make(map[int]struct{})
+	sc := bufio.NewScanner(strings.NewReader(diff))
+	for sc.Scan() {
+		m := hunkHeaderRe.FindStringSubmatch(sc.Text())
+		if m == nil {
+			continue
+		}
+		start, err := strconv.Atoi(m[1])
+		if err != nil {
+			continue
+		}
+		count := 1
+		if m[2] != "" {
+			count, err = strconv.Atoi(m[2])
+			if err != nil {
+				continue
+			}
+		}
+		for i := 0; i < count; i++ {
+			res[start+i] = struct{}{}
+		}
+	}
+	return res
 }
 
 func moduleVersion(goMod *modfile.File, imp string) *module.Version {

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -1,12 +1,83 @@
 package analyzer
 
 import (
+	"bytes"
+	"context"
+	"go/token"
+	"io"
+	"os"
+	"strings"
 	"testing"
 
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
 	"gotest.tools/v3/assert"
 )
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	assert.NilError(t, err)
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	fn()
+	_ = w.Close()
+	os.Stdout = orig
+	return <-done
+}
+
+func TestFlushGHAPrioritizesAndCaps(t *testing.T) {
+	sumPosn := func(line int) token.Position {
+		return token.Position{Filename: "/repo/go.sum", Line: line, Column: 1}
+	}
+
+	t.Run("only go.sum is annotated", func(t *testing.T) {
+		inst := &instance{Opts: Opts{GHA: true}, cwd: "/repo"}
+		inst.addGHAFinding(ghaFinding{msg: "m", sumPosn: sumPosn(3)})
+		out := captureStdout(t, func() { inst.flushGHA(context.Background()) })
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		assert.Equal(t, 1, len(lines))
+		assert.Assert(t, strings.Contains(lines[0], "file=go.sum"), "must annotate go.sum: %q", lines[0])
+		assert.Assert(t, !strings.Contains(out, ".go,"), "must not annotate .go files: %q", out)
+	})
+
+	t.Run("changed-in-PR findings emitted first", func(t *testing.T) {
+		inst := &instance{Opts: Opts{GHA: true}, cwd: "/repo"}
+		inst.addGHAFinding(ghaFinding{msg: "other-finding", sumPosn: sumPosn(1)})
+		inst.addGHAFinding(ghaFinding{msg: "priority-finding", sumPosn: sumPosn(9), changedInPR: true})
+		out := captureStdout(t, func() { inst.flushGHA(context.Background()) })
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		assert.Equal(t, 2, len(lines))
+		assert.Assert(t, strings.Contains(lines[0], "priority-finding"), "changed-in-PR finding should be first: %q", lines[0])
+		assert.Assert(t, strings.Contains(lines[1], "other-finding"))
+	})
+
+	t.Run("caps total annotations", func(t *testing.T) {
+		inst := &instance{Opts: Opts{GHA: true}, cwd: "/repo"}
+		for i := 0; i < 60; i++ {
+			inst.addGHAFinding(ghaFinding{msg: "m", sumPosn: sumPosn(i + 1)})
+		}
+		out := captureStdout(t, func() { inst.flushGHA(context.Background()) })
+		assert.Equal(t, ghaMaxAnnotations, strings.Count(out, "::warning"))
+	})
+
+	t.Run("changed-in-PR findings survive the cap", func(t *testing.T) {
+		inst := &instance{Opts: Opts{GHA: true}, cwd: "/repo"}
+		// Fill well past the cap with unchanged findings, then add one changed.
+		for i := 0; i < 60; i++ {
+			inst.addGHAFinding(ghaFinding{msg: "other-finding", sumPosn: sumPosn(i + 1)})
+		}
+		inst.addGHAFinding(ghaFinding{msg: "priority-finding", sumPosn: sumPosn(999), changedInPR: true})
+		out := captureStdout(t, func() { inst.flushGHA(context.Background()) })
+		assert.Assert(t, strings.Contains(out, "priority-finding"), "changed-in-PR finding must survive the cap")
+	})
+}
 
 func TestModuleVersion(t *testing.T) {
 	tests := []struct {
@@ -107,6 +178,77 @@ require github.com/bar/baz v1.0.0
 				assert.Assert(t, got != nil, "expected %v, got nil", tt.expected)
 				assert.Equal(t, tt.expected.Path, got.Path)
 				assert.Equal(t, tt.expected.Version, got.Version)
+			}
+		})
+	}
+}
+
+func TestParseDiffNewLines(t *testing.T) {
+	tests := []struct {
+		name     string
+		diff     string
+		expected []int
+	}{
+		{
+			name:     "empty diff",
+			diff:     "",
+			expected: nil,
+		},
+		{
+			name: "single added line",
+			diff: `diff --git a/go.sum b/go.sum
+index 111..222 100644
+--- a/go.sum
++++ b/go.sum
+@@ -5 +5,1 @@
++example.com/foo v1.0.0 h1:abc=
+`,
+			expected: []int{5},
+		},
+		{
+			name: "multiple added lines in one hunk",
+			diff: `@@ -10,0 +11,3 @@
++a
++b
++c
+`,
+			expected: []int{11, 12, 13},
+		},
+		{
+			name: "implicit count of one",
+			diff: `@@ -1 +2 @@
++x
+`,
+			expected: []int{2},
+		},
+		{
+			name: "pure deletion has no new lines",
+			diff: `@@ -3,2 +2,0 @@
+-gone1
+-gone2
+`,
+			expected: nil,
+		},
+		{
+			name: "multiple hunks",
+			diff: `@@ -1 +1 @@
+-old
++new
+@@ -8,0 +9,2 @@
++p
++q
+`,
+			expected: []int{1, 9, 10},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseDiffNewLines(tt.diff)
+			assert.Equal(t, len(tt.expected), len(got), "got %v", got)
+			for _, want := range tt.expected {
+				_, ok := got[want]
+				assert.Assert(t, ok, "expected line %d in %v", want, got)
 			}
 		})
 	}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"log/slog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -42,6 +41,7 @@ import (
 	"github.com/AkihiroSuda/gosocialcheck/pkg/categories"
 	"github.com/AkihiroSuda/gosocialcheck/pkg/netutil"
 	"github.com/AkihiroSuda/gosocialcheck/pkg/netutil/github"
+	"github.com/AkihiroSuda/gosocialcheck/pkg/progress"
 	"github.com/AkihiroSuda/gosocialcheck/pkg/source/cncf"
 )
 
@@ -77,21 +77,11 @@ const (
 	DefaultRemoteURL = "https://github.com/AkihiroSuda/gosocialcheck-cache.git"
 )
 
-type ProgressEvent struct {
-	Message string `json:"message,omitempty"`
-}
-
-type ProgressEventHandler func(context.Context, ProgressEvent)
-
-func DefaultProgressEventHandler(ctx context.Context, ev ProgressEvent) {
-	slog.DebugContext(ctx, "progress: "+ev.Message)
-}
-
 type opts struct {
 	dir        string
 	mode       Mode
 	remoteURL  string
-	onProgress ProgressEventHandler
+	onProgress progress.Handler
 	httpClient *http.Client
 }
 
@@ -127,7 +117,7 @@ func WithRemoteURL(url string) Opt {
 	}
 }
 
-func WithProgressEventHandler(onProgress ProgressEventHandler) Opt {
+func WithProgressEventHandler(onProgress progress.Handler) Opt {
 	return func(opts *opts) error {
 		opts.onProgress = onProgress
 		return nil
@@ -163,7 +153,7 @@ func New(o ...Opt) (*Cache, error) {
 		c.opts.remoteURL = DefaultRemoteURL
 	}
 	if c.opts.onProgress == nil {
-		c.opts.onProgress = DefaultProgressEventHandler
+		c.opts.onProgress = progress.DefaultHandler
 	}
 	if c.opts.httpClient == nil {
 		c.opts.httpClient = http.DefaultClient
@@ -347,7 +337,7 @@ func (c *Cache) updateRemote(ctx context.Context) error {
 	_, statErr := os.Stat(gitDir)
 	switch {
 	case errors.Is(statErr, fs.ErrNotExist):
-		c.onProgress(ctx, ProgressEvent{Message: "cloning " + c.opts.remoteURL})
+		c.onProgress(ctx, progress.Event{Message: "cloning " + c.opts.remoteURL})
 		args := []string{"clone", "--depth", "1", c.opts.remoteURL, dir}
 		if out, err := runGit(ctx, "", args...); err != nil {
 			return fmt.Errorf("git clone failed: %w: %s", err, out)
@@ -355,7 +345,7 @@ func (c *Cache) updateRemote(ctx context.Context) error {
 	case statErr != nil:
 		return statErr
 	default:
-		c.onProgress(ctx, ProgressEvent{Message: "fetching " + c.opts.remoteURL})
+		c.onProgress(ctx, progress.Event{Message: "fetching " + c.opts.remoteURL})
 		if out, err := runGit(ctx, dir, "fetch", "--depth", "1", "origin"); err != nil {
 			return fmt.Errorf("git fetch failed: %w: %s", err, out)
 		}
@@ -503,11 +493,10 @@ func (c *Cache) updateGitHubRepoTag(ctx context.Context, repo *github.Repo, tag 
 	if err := os.WriteFile(metaF, metaB, 0o644); err != nil {
 		return err
 	}
-	progress := ProgressEvent{
+	c.onProgress(ctx, progress.Event{
 		Message: fmt.Sprintf("%s/%s %s %s (%s)",
 			repo.Owner, repo.Repo, tag.Name, tag.Commit.SHA, category),
-	}
-	c.onProgress(ctx, progress)
+	})
 	return nil
 }
 

--- a/pkg/progress/progress.go
+++ b/pkg/progress/progress.go
@@ -1,0 +1,16 @@
+package progress
+
+import (
+	"context"
+	"log/slog"
+)
+
+type Event struct {
+	Message string `json:"message,omitempty"`
+}
+
+type Handler func(context.Context, Event)
+
+func DefaultHandler(ctx context.Context, ev Event) {
+	slog.DebugContext(ctx, "progress: "+ev.Message)
+}


### PR DESCRIPTION
On a pull_request event (detected via GITHUB_BASE_REF), restrict findings to modules whose go.sum line was added or modified in the PR diff, to stay within GitHub Actions annotation limits. Falls back to checking all lines when the diff cannot be computed.

Fixes #69