### PR TITLE
analyzer: in --gha mode, annotate only PR-changed modules

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -131,10 +131,11 @@ type modInfo struct {
 }
 
 type ghaFinding struct {
-	msg         string
-	sumPosn     token.Position // go.sum line to annotate (--gha mode)
-	modPosn     token.Position // go.mod line to report (non-gha indirect findings)
-	changedInPR bool           // go.sum line was added/changed in the pull request
+	msg            string
+	sumPosn        token.Position // go.sum line to annotate (--gha mode)
+	modPosn        token.Position // go.mod line to report (non-gha indirect findings)
+	changedInPR    bool           // go.sum line was added/changed in the pull request
+	changeSetKnown bool           // the pull request change set for the go.sum file was determinable
 }
 
 func run(ctx context.Context, inst *instance) func(*analysis.Pass) (any, error) {
@@ -234,6 +235,7 @@ func run(ctx context.Context, inst *instance) func(*analysis.Pass) (any, error) 
 								},
 							}
 							if changed, ok := inst.changedGoSumLines(ctx, goSumFilename); ok {
+								f.changeSetKnown = true
 								_, f.changedInPR = changed[goSumE.Line]
 							}
 							inst.addGHAFinding(f)
@@ -258,8 +260,10 @@ func run(ctx context.Context, inst *instance) func(*analysis.Pass) (any, error) 
 }
 
 // ghaMaxAnnotations bounds how many GitHub Actions annotations --gha emits, to
-// stay within GitHub's per-run limit (50). Findings whose go.sum line changed in
-// the pull request are emitted first, so the most relevant ones survive the cap.
+// stay within GitHub's per-run limit (50). On a pull request, findings for
+// untouched modules are dropped entirely (see flushGHA); the cap is a backstop
+// for events where the change set is unknown. Findings whose go.sum line changed
+// in the pull request are emitted first, so the most relevant ones survive.
 const ghaMaxAnnotations = 50
 
 func (inst *instance) recordModule(mi *modInfo) {
@@ -371,6 +375,7 @@ func (inst *instance) collectIndirect(ctx context.Context) ([]ghaFinding, error)
 					Column:   1,
 				}
 				if changed, ok := inst.changedGoSumLines(ctx, mi.goSumFilename); ok {
+					f.changeSetKnown = true
 					_, f.changedInPR = changed[goSumE.Line]
 				}
 			}
@@ -403,6 +408,21 @@ func (inst *instance) flushGHA(ctx context.Context) {
 	findings := inst.ghaFindings
 	inst.ghaFindings = nil
 	inst.ghaFindingsMu.Unlock()
+
+	// On a pull request, annotate only the modules actually added/changed in the
+	// PR: warnings for untouched modules are just noise and waste the limited
+	// annotation budget (issue #69). When the change set for a finding's go.sum
+	// file could not be determined (e.g. not a pull_request event, or the base
+	// branch could not be fetched), keep the finding and fall back to the
+	// prioritize-and-cap behavior below.
+	kept := findings[:0]
+	for _, f := range findings {
+		if f.changeSetKnown && !f.changedInPR {
+			continue
+		}
+		kept = append(kept, f)
+	}
+	findings = kept
 
 	// Deterministic order regardless of how passes were scheduled: PR-changed
 	// findings first, then by go.sum line and message.

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -81,6 +81,26 @@ func TestFlushGHAPrioritizesAndCaps(t *testing.T) {
 		out := captureStdout(t, func() { inst.flushGHA(context.Background()) })
 		assert.Assert(t, strings.Contains(out, "priority-finding"), "changed-in-PR finding must survive the cap")
 	})
+
+	t.Run("drops untouched modules when the PR change set is known", func(t *testing.T) {
+		inst := &instance{Opts: Opts{GHA: true}, cwd: "/repo"}
+		// Known change set, but module not touched in the PR: must be dropped.
+		inst.addGHAFinding(ghaFinding{msg: "untouched-finding", sumPosn: sumPosn(1), changeSetKnown: true})
+		inst.addGHAFinding(ghaFinding{msg: "touched-finding", sumPosn: sumPosn(2), changeSetKnown: true, changedInPR: true})
+		out := captureStdout(t, func() { inst.flushGHA(context.Background()) })
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		assert.Equal(t, 1, len(lines))
+		assert.Assert(t, strings.Contains(out, "touched-finding"), "touched module must be annotated: %q", out)
+		assert.Assert(t, !strings.Contains(out, "untouched-finding"), "untouched module must not be annotated: %q", out)
+	})
+
+	t.Run("keeps findings when the change set is unknown", func(t *testing.T) {
+		inst := &instance{Opts: Opts{GHA: true}, cwd: "/repo"}
+		// Change set could not be determined (e.g. push event): keep the finding.
+		inst.addGHAFinding(ghaFinding{msg: "unknown-finding", sumPosn: sumPosn(1)})
+		out := captureStdout(t, func() { inst.flushGHA(context.Background()) })
+		assert.Assert(t, strings.Contains(out, "unknown-finding"), "finding must survive when change set is unknown: %q", out)
+	})
 }
 
 func TestModuleVersion(t *testing.T) {


### PR DESCRIPTION
The #70 fix merely deprioritized findings for modules untouched by the pull request, so they were still emitted (up to the cap) and wasted the limited annotation budget. When the PR change set for a go.sum file is determinable, drop findings for untouched modules entirely; fall back to prioritize-and-cap only when the change set is unknown (e.g. push event).

Fixes #69