### PR TITLE
analyzer: fetch the base ref only when it is missing

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -463,23 +463,58 @@ func (inst *instance) computeChangedGoSumLines(ctx context.Context, goSumFilenam
 	}
 	dir := filepath.Dir(goSumFilename)
 	base := filepath.Base(goSumFilename)
-	// actions/checkout makes a shallow clone that omits the base branch, so fetch
-	// its tip on demand (into FETCH_HEAD) instead of requiring fetch-depth: 0.
-	inst.progress(ctx, fmt.Sprintf("fetching the base ref %q", baseRef))
-	if out, err := runGit(ctx, dir, "fetch", "--no-tags", "--depth=1", "origin", baseRef); err != nil {
-		slog.WarnContext(ctx, "could not fetch base branch for --gha; not prioritizing PR-changed go.sum lines",
-			"baseRef", baseRef, "error", err, "output", out)
+	baseTip, ok := inst.resolveBaseTip(ctx, dir, baseRef)
+	if !ok {
 		return nil
 	}
-	// Diff the fetched base tip against the working tree, so the reported line
+	// Diff the base tip against the working tree, so the reported line
 	// numbers match the go.sum the analyzer read.
-	out, err := runGitDiff(ctx, dir, "FETCH_HEAD", base)
+	out, err := runGitDiff(ctx, dir, baseTip, base)
 	if err != nil {
 		slog.WarnContext(ctx, "could not diff go.sum against base branch for --gha",
 			"baseRef", baseRef, "error", err)
 		return nil
 	}
 	return parseDiffNewLines(out)
+}
+
+// resolveBaseTip returns the git ref to diff the working tree against for the
+// pull_request base branch. It prefers a local branch when it is newer than the
+// remote-tracking ref (e.g. when the base branch is checked out and ahead of
+// origin), then the remote-tracking ref (e.g. with fetch-depth: 0). When the
+// base branch is absent locally (actions/checkout's default shallow clone omits
+// it), it fetches the tip on demand into FETCH_HEAD.
+func (inst *instance) resolveBaseTip(ctx context.Context, dir, baseRef string) (string, bool) {
+	localRef := "refs/heads/" + baseRef
+	remoteRef := "origin/" + baseRef
+	localOK := gitRefExists(ctx, dir, localRef)
+	remoteOK := gitRefExists(ctx, dir, remoteRef)
+	switch {
+	case localOK && remoteOK:
+		// Prefer the local branch only when the remote tip is an ancestor of
+		// it (i.e. the local branch is newer); otherwise the remote tip is at
+		// least as up to date.
+		if _, err := runGit(ctx, dir, "merge-base", "--is-ancestor", remoteRef, localRef); err == nil {
+			return localRef, true
+		}
+		return remoteRef, true
+	case localOK:
+		return localRef, true
+	case remoteOK:
+		return remoteRef, true
+	}
+	inst.progress(ctx, fmt.Sprintf("fetching the base ref %q", baseRef))
+	if out, err := runGit(ctx, dir, "fetch", "--no-tags", "--depth=1", "origin", baseRef); err != nil {
+		slog.WarnContext(ctx, "could not fetch base branch for --gha; not prioritizing PR-changed go.sum lines",
+			"baseRef", baseRef, "error", err, "output", out)
+		return "", false
+	}
+	return "FETCH_HEAD", true
+}
+
+func gitRefExists(ctx context.Context, dir, ref string) bool {
+	_, err := runGit(ctx, dir, "rev-parse", "--verify", "--quiet", ref+"^{commit}")
+	return err == nil
 }
 
 func runGit(ctx context.Context, dir string, args ...string) (string, error) {

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -6,6 +6,8 @@ import (
 	"go/token"
 	"io"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -415,6 +417,126 @@ index 111..222 100644
 			}
 		})
 	}
+}
+
+func gitT(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := runGit(context.Background(), dir, args...)
+	assert.NilError(t, err, "git %v: %s", args, out)
+	return out
+}
+
+func initRepoT(t *testing.T, dir string) {
+	t.Helper()
+	assert.NilError(t, os.MkdirAll(dir, 0o755))
+	gitT(t, dir, "-c", "init.defaultBranch=master", "init")
+	gitT(t, dir, "config", "user.email", "test@example.com")
+	gitT(t, dir, "config", "user.name", "test")
+	gitT(t, dir, "config", "commit.gpgsign", "false")
+}
+
+func commitFileT(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644))
+	gitT(t, dir, "add", name)
+	gitT(t, dir, "commit", "-m", "commit "+content)
+	return gitT(t, dir, "rev-parse", "HEAD")
+}
+
+func TestResolveBaseTip(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	inst := &instance{}
+
+	t.Run("remote-tracking ref only", func(t *testing.T) {
+		root := t.TempDir()
+		upstream := filepath.Join(root, "upstream")
+		work := filepath.Join(root, "work")
+		initRepoT(t, upstream)
+		commitFileT(t, upstream, "f", "c1")
+		initRepoT(t, work)
+		gitT(t, work, "remote", "add", "origin", upstream)
+		gitT(t, work, "fetch", "origin")
+
+		ref, ok := inst.resolveBaseTip(context.Background(), work, "master")
+		assert.Assert(t, ok)
+		assert.Equal(t, "origin/master", ref)
+	})
+
+	t.Run("local branch only", func(t *testing.T) {
+		root := t.TempDir()
+		work := filepath.Join(root, "work")
+		initRepoT(t, work)
+		commitFileT(t, work, "f", "c1")
+
+		ref, ok := inst.resolveBaseTip(context.Background(), work, "master")
+		assert.Assert(t, ok)
+		assert.Equal(t, "refs/heads/master", ref)
+	})
+
+	t.Run("local branch newer than remote is preferred", func(t *testing.T) {
+		root := t.TempDir()
+		upstream := filepath.Join(root, "upstream")
+		work := filepath.Join(root, "work")
+		initRepoT(t, upstream)
+		commitFileT(t, upstream, "f", "c1")
+		initRepoT(t, work)
+		gitT(t, work, "remote", "add", "origin", upstream)
+		gitT(t, work, "fetch", "origin")
+		// Local master starts at origin/master, then advances ahead of it.
+		gitT(t, work, "checkout", "-B", "master", "origin/master")
+		commitFileT(t, work, "f", "c2")
+
+		ref, ok := inst.resolveBaseTip(context.Background(), work, "master")
+		assert.Assert(t, ok)
+		assert.Equal(t, "refs/heads/master", ref)
+	})
+
+	t.Run("remote newer than local branch is preferred", func(t *testing.T) {
+		root := t.TempDir()
+		upstream := filepath.Join(root, "upstream")
+		work := filepath.Join(root, "work")
+		initRepoT(t, upstream)
+		c1 := commitFileT(t, upstream, "f", "c1")
+		initRepoT(t, work)
+		gitT(t, work, "remote", "add", "origin", upstream)
+		gitT(t, work, "fetch", "origin")
+		// Local master stays at c1 while origin advances to c2.
+		gitT(t, work, "update-ref", "refs/heads/master", c1)
+		commitFileT(t, upstream, "f", "c2")
+		gitT(t, work, "fetch", "origin")
+
+		ref, ok := inst.resolveBaseTip(context.Background(), work, "master")
+		assert.Assert(t, ok)
+		assert.Equal(t, "origin/master", ref)
+	})
+
+	t.Run("fetches into FETCH_HEAD when absent locally", func(t *testing.T) {
+		root := t.TempDir()
+		upstream := filepath.Join(root, "upstream")
+		work := filepath.Join(root, "work")
+		initRepoT(t, upstream)
+		commitFileT(t, upstream, "f", "c1")
+		initRepoT(t, work)
+		// Remote is configured but never fetched: no origin/master, no local master.
+		gitT(t, work, "remote", "add", "origin", upstream)
+
+		ref, ok := inst.resolveBaseTip(context.Background(), work, "master")
+		assert.Assert(t, ok)
+		assert.Equal(t, "FETCH_HEAD", ref)
+	})
+
+	t.Run("returns false when the base ref cannot be obtained", func(t *testing.T) {
+		root := t.TempDir()
+		work := filepath.Join(root, "work")
+		initRepoT(t, work)
+		commitFileT(t, work, "f", "c1")
+		// No remote and no branch named "missing".
+		ref, ok := inst.resolveBaseTip(context.Background(), work, "missing")
+		assert.Assert(t, !ok)
+		assert.Equal(t, "", ref)
+	})
 }
 
 func TestIsLocalPath(t *testing.T) {


### PR DESCRIPTION
Prefer the already-checked-out base branch (e.g. fetch-depth: 0) and fall back to an on-demand fetch into FETCH_HEAD only when origin/<baseRef> is not present locally.